### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Test Laravel Url Shortener
+APP_NAME="Test Laravel Url Shortener"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true


### PR DESCRIPTION
YAML doesn't like spaces in string values, needs wrapping quotation-marks.
Causing `artisan` commands to fail during `ddev install`

<img width="932" alt="Screen Shot 2020-08-03 at 10 26 08 AM" src="https://user-images.githubusercontent.com/291025/89209744-c0c03a00-d573-11ea-8fb0-f1850bfc4ee3.png">
